### PR TITLE
[WIP] [image_picker] Support for web (through IOOverrides)

### DIFF
--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -5,12 +5,40 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:file/file.dart' as file;
+import 'package:file/local.dart';
+import 'package:file/memory.dart';
+import 'package:flutter/foundation.dart';
+
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:video_player/video_player.dart';
 
 void main() {
-  runApp(MyApp());
+  if (kIsWeb) {
+    final file.FileSystem fs = MemoryFileSystem(); // We need a more persistent FS.
+    IOOverrides.runZoned(() {
+        IOOverrides.global = IOOverrides.current; // Welcome to the web, dart:io
+        runApp(MyApp());
+      },
+      createDirectory: (String path) => fs.directory(path),
+      createFile: (String path) => fs.file(path),
+      createLink: (String path) => fs.link(path),
+      getCurrentDirectory: () => fs.currentDirectory,
+      setCurrentDirectory: (String path) => fs.currentDirectory = path,
+      getSystemTempDirectory: () => fs.systemTempDirectory,
+      stat: (String path) => fs.stat(path),
+      statSync: (String path) => fs.statSync(path),
+      fseIdentical: (String p1, String p2) => fs.identical(p1, p2),
+      fseIdenticalSync: (String p1, String p2) => fs.identicalSync(p1, p2),
+      fseGetType: (String path, bool followLinks) => fs.type(path, followLinks: followLinks),
+      fseGetTypeSync: (String path, bool followLinks) => fs.typeSync(path, followLinks: followLinks),
+      fsWatch: (String a, int b, bool c) => throw UnsupportedError('unsupported'),
+      fsWatchIsSupported: () => false,
+    );
+  } else {
+    runApp(MyApp());
+  }
 }
 
 class MyApp extends StatelessWidget {
@@ -154,7 +182,7 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Text(widget.title),
       ),
       body: Center(
-        child: Platform.isAndroid
+        child: /*Platform.isAndroid
             ? FutureBuilder<void>(
                 future: retrieveLostData(),
                 builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
@@ -182,7 +210,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   }
                 },
               )
-            : (isVideo ? _previewVideo() : _previewImage()),
+            : */(isVideo ? _previewVideo() : _previewImage()),
       ),
       floatingActionButton: Column(
         mainAxisAlignment: MainAxisAlignment.end,

--- a/packages/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/example/pubspec.yaml
@@ -4,6 +4,7 @@ author: Flutter Team <flutter-dev@googlegroups.com>
 
 dependencies:
   video_player: 0.10.1+5
+  file: ^5.0.10
   flutter:
     sdk: flutter
   image_picker:

--- a/packages/image_picker/example/web/index.html
+++ b/packages/image_picker/example/web/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>web</title>
+</head>
+<body>
+  <script src="main.dart.js" type="application/javascript"></script>
+</body>
+</html>

--- a/packages/image_picker/lib/image_picker_plugin.dart
+++ b/packages/image_picker/lib/image_picker_plugin.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+import 'dart:async';
+import 'dart:html' as html;
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'image_picker.dart'; // For types
+
+final String _kImagePickerInputsDomId = '__image_picker_web-file-input';
+final String _kAcceptImageMimeType = 'image/*';
+final String _kAcceptVideoMimeType = 'video/*';
+
+/// ImagePickerPlugin using dart:io
+///
+/// This plugin assumes the user has wrapped their app in an IOOverride call,
+/// configuring the appropriate package:file FileSystem
+class ImagePickerPlugin {
+
+  static html.Element target;
+
+  static void registerWith(Registrar registrar) {
+    final MethodChannel channel = MethodChannel(
+      'plugins.flutter.io/image_picker',
+      const StandardMethodCodec(),
+      registrar.messenger);
+
+    final ImagePickerPlugin instance = ImagePickerPlugin();
+    channel.setMethodCallHandler(instance.handleMethodCall);
+
+    target = html.querySelector('#${_kImagePickerInputsDomId}');
+    if (target == null) {
+      final html.Element targetElement = html.Element.tag('flt-image-picker-inputs')
+        ..id=_kImagePickerInputsDomId;
+
+      html.querySelector('body').children.add(targetElement);
+      target = targetElement;
+    }
+  }
+
+  /// Reads bytes from an html.File
+  Future<Uint8List> _readFileContents(html.File file) {
+    assert(file != null);
+
+    // Wrap html.FileReader in a Completer
+    final Completer<Uint8List> _fileReader = Completer<Uint8List>();
+    final html.FileReader reader = html.FileReader();
+
+    reader.onLoad.listen((html.ProgressEvent event) {
+      final html.FileReader reader = event.target;
+      _fileReader.complete(reader.result);
+    });
+    reader.onError.listen((html.ProgressEvent event) {
+      final html.FileReader reader = event.target;
+      _fileReader.completeError(reader.error);
+    });
+    reader.readAsArrayBuffer(file);
+
+    return _fileReader.future;
+  }
+
+  /// Handles the OnChange event from a FileUploadInputElement object
+  /// Returns the selected file, written to an in-memory FileSystem
+  Future<File> _handleOnChangeEvent(html.Event event) async {
+    // load the file...
+    final html.FileUploadInputElement input = event.target;
+    final html.File file = input.files[0];
+
+    if (file != null) {
+      final Uint8List result = await _readFileContents(file); // Returns bytes...
+      final File output = await File('${Directory.systemTemp.path}/${file.name}').create();
+      return output.writeAsBytes(result);
+    }
+    return null;
+  }
+
+  /// Monitors an <input type="file"> and returns the selected file.
+  Future<File> _getSelectedFile(html.FileUploadInputElement input) async {
+    // Observe the input until we can return something
+    final Completer<File> _completer = Completer<File>();
+    input
+      .onChange
+        .listen((html.Event event) async {
+          _completer.complete(_handleOnChangeEvent(event));
+        });
+    input
+      .onError // What other events signal failure?
+        .listen((html.Event event) {
+          _completer.completeError(event);
+        });
+
+    return _completer.future;
+  }
+
+  Future<dynamic> handleMethodCall(MethodCall call) async {
+    assert(IOOverrides.current != null);
+
+    switch(call.method) {
+      case 'pickImage':
+        html.FileUploadInputElement input = _createInputElement(_kAcceptImageMimeType, call.arguments);
+        _injectAndActivate(input);
+        final File file = await _getSelectedFile(input);
+        return file.path;
+        break;
+      case 'pickVideo':
+        html.FileUploadInputElement input = _createInputElement(_kAcceptVideoMimeType, call.arguments);
+        _injectAndActivate(input);
+        final File file = await _getSelectedFile(input);
+        return file.path;
+        break;
+      default:
+        throw PlatformException(
+                code: 'Unimplemented',
+                details: 'The image_picker plugin for web doesn\'t implement the method \'${call.method}\''
+              );
+    }
+  }
+
+  /// Injects the file input element, and clicks on it
+  void _injectAndActivate(html.Element element) {
+    target.children.clear();
+    target.children.add(element);
+    element.click();
+  }
+
+  html.Element _createInputElement(String accept, dynamic arguments) {
+    html.Element element;
+
+    if (arguments['source'] == ImageSource.camera.index) {
+      // Capture is not supported by dart:html :/
+      element = html.Element.html(
+          '<input type="file" accept="$accept" capture />',
+          validator: html.NodeValidatorBuilder()
+                      ..allowElement(
+                        'input',
+                        attributes: ['type', 'accept', 'capture']
+                      )
+      );
+    } else {
+      element = html.FileUploadInputElement()
+        ..accept = accept;
+    }
+
+    return element;
+  }
+}

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -9,12 +9,20 @@ version: 0.6.1+4
 
 flutter:
   plugin:
-    androidPackage: io.flutter.plugins.imagepicker
-    iosPrefix: FLT
-    pluginClass: ImagePickerPlugin
+    platforms:
+      android:
+        package: io.flutter.plugins.imagepicker
+        pluginClass: ImagePickerPlugin
+      ios:
+        pluginClass: ImagePickerPlugin
+      web:
+        pluginClass: ImagePickerPlugin
+        fileName: image_picker_plugin.dart
 
 dependencies:
   flutter:
+    sdk: flutter
+  flutter_web_plugins:
     sdk: flutter
 
 dev_dependencies:


### PR DESCRIPTION
# DO NOT MERGE THIS

## Description

This approach (compare to the [old one](https://github.com/ditman/plugins/pull/6)) uses [IOOverrides](https://api.flutter.dev/flutter/dart-io/IOOverrides-class.html) to configure dart:io to use a MemoryFileSystem from package:file as its backend. The configuration happens on the main() entrypoint of the app.

This allows all plugins that use file operations from dart:io to work without major modifications on the web.

The web version of the file_picker plugin also uses dart:io as if it were normally available.

Limitations: the overrides are NOT set at plugin registration time, so usages of dart:io will fail there. In order to overcome this limitation, the IOOverrides configuration needs to be extracted to the [generated main entrypoint](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/build_runner/build_script.dart#L369-L373), where plugins are initialized and the app is really kickstarted.